### PR TITLE
Add input for local instance

### DIFF
--- a/frontend/src/components/CommunityCard.jsx
+++ b/frontend/src/components/CommunityCard.jsx
@@ -20,7 +20,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { ContentSkeleton, ContentError } from "./Display";
 import CopyLink from "./CopyLink";
 
-function CommunityCard({ community, localURL = '' }) {
+function CommunityCard({ community, localURL = "" }) {
   const [loadedBanner, setLoadedBanner] = React.useState(false);
   const [bannerError, setBannerError] = React.useState(false);
 
@@ -70,13 +70,23 @@ function CommunityCard({ community, localURL = '' }) {
                 textOverflow: "ellipsis",
               }}
             >
-              <Tooltip title={"Visit: " + community.title + (localURL ? " inside " + localURL : "")} variant="soft" placement="top-start">
+              <Tooltip
+                title={"Visit: " + community.title + (localURL ? " inside " + localURL : "")}
+                variant="soft"
+                placement="top-start"
+              >
                 <Link
                   level="body1"
                   variant="plain"
                   alt={community.title}
                   color="neutral"
-                  href={localURL ? `https://${localURL}/c/${community.name}@${community.url && community.url.split("/")[2]}` : community.url}
+                  href={
+                    localURL
+                      ? `https://${localURL}/c/${community.name}@${
+                          community.url && community.url.split("/")[2]
+                        }`
+                      : community.url
+                  }
                   target="_blank"
                 >
                   {community.title}

--- a/frontend/src/components/CommunityCard.jsx
+++ b/frontend/src/components/CommunityCard.jsx
@@ -20,7 +20,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { ContentSkeleton, ContentError } from "./Display";
 import CopyLink from "./CopyLink";
 
-function CommunityCard({ community }) {
+function CommunityCard({ community, localURL = '' }) {
   const [loadedBanner, setLoadedBanner] = React.useState(false);
   const [bannerError, setBannerError] = React.useState(false);
 
@@ -70,13 +70,13 @@ function CommunityCard({ community }) {
                 textOverflow: "ellipsis",
               }}
             >
-              <Tooltip title={"Visit: " + community.title} variant="soft" placement="top-start">
+              <Tooltip title={"Visit: " + community.title + (localURL ? " inside " + localURL : "")} variant="soft" placement="top-start">
                 <Link
                   level="body1"
                   variant="plain"
                   alt={community.title}
                   color="neutral"
-                  href={community.url}
+                  href={localURL ? `https://${localURL}/c/${community.name}@${community.url && community.url.split("/")[2]}` : community.url}
                   target="_blank"
                 >
                   {community.title}

--- a/frontend/src/pages/Communities.jsx
+++ b/frontend/src/pages/Communities.jsx
@@ -29,6 +29,9 @@ export default function Communities() {
 
   const [filterText, setFilterText] = useStorage("community.filterText", "");
 
+  const [useLocalURL, setUseLocalURL] = useStorage("community.useLocalURL", false);
+  const [localURL, setLocalURL] = useStorage("community.localURL", "");
+
   const { isLoading, isSuccess, isError, error, data } = useQueryCache(
     "communitiesData",
     "/communities.json",
@@ -101,7 +104,7 @@ export default function Communities() {
 
     setCommunitiesData(communties);
     setProcessingData(false);
-  }, [data, showNsfw, orderBy, filterText, hideNoBanner, page, pageLimit]);
+  }, [data, showNsfw, orderBy, filterText, hideNoBanner, page, pageLimit, localURL]);
 
   return (
     <Container maxWidth={false} sx={{}}>
@@ -125,6 +128,17 @@ export default function Communities() {
             flexShrink: 0,
           }}
           onChange={(event) => setFilterText(event.target.value)}
+        />
+
+        <Input
+          placeholder="Your Instance URL e.g 'lemmy.tgxn.net'"
+          value={(useLocalURL ? localURL : "")}
+          sx={{
+            width: { xs: "100%", sm: 240 },
+            flexShrink: 0,
+            display: (useLocalURL ? "auto" : "None")
+          }}
+          onChange={(event) => setLocalURL(event.target.value.replace("http:", "").replace("https:", "").replace("//","").replace("/", ""))}
         />
 
         <Select
@@ -166,6 +180,12 @@ export default function Communities() {
             checked={hideNoBanner}
             onChange={(event) => setHideNoBanner(event.target.checked)}
           />
+          
+          <Checkbox
+            label="Enable Local URLs"
+            checked={useLocalURL}
+            onChange={(event) => {setUseLocalURL(event.target.checked); (event.target.checked ? "" : setLocalURL(""))}}
+          />
         </Box>
         <Box
           sx={{
@@ -191,7 +211,7 @@ export default function Communities() {
         {isSuccess && !processingData && (
           <Grid container spacing={2}>
             {communitiesData.map((community, index) => (
-              <CommunityCard key={index} community={community} />
+              <CommunityCard key={index} community={community} localURL={localURL}/>
             ))}
           </Grid>
         )}

--- a/frontend/src/pages/Communities.jsx
+++ b/frontend/src/pages/Communities.jsx
@@ -13,6 +13,8 @@ import Checkbox from "@mui/joy/Checkbox";
 
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import SortIcon from "@mui/icons-material/Sort";
+import SearchIcon from "@mui/icons-material/Search";
+import HomeIcon from "@mui/icons-material/Home";
 
 import CommunityCard from "../components/CommunityCard";
 import Pagination from "../components/Pagination";
@@ -121,6 +123,7 @@ export default function Communities() {
         }}
       >
         <Input
+          startDecorator={<SearchIcon />}
           placeholder="Filter Communities"
           value={filterText}
           sx={{
@@ -128,17 +131,6 @@ export default function Communities() {
             flexShrink: 0,
           }}
           onChange={(event) => setFilterText(event.target.value)}
-        />
-
-        <Input
-          placeholder="Your Instance URL e.g 'lemmy.tgxn.net'"
-          value={(useLocalURL ? localURL : "")}
-          sx={{
-            width: { xs: "100%", sm: 240 },
-            flexShrink: 0,
-            display: (useLocalURL ? "auto" : "None")
-          }}
-          onChange={(event) => setLocalURL(event.target.value.replace("http:", "").replace("https:", "").replace("//","").replace("/", ""))}
         />
 
         <Select
@@ -180,13 +172,35 @@ export default function Communities() {
             checked={hideNoBanner}
             onChange={(event) => setHideNoBanner(event.target.checked)}
           />
-          
+
           <Checkbox
             label="Enable Local URLs"
             checked={useLocalURL}
-            onChange={(event) => {setUseLocalURL(event.target.checked); (event.target.checked ? "" : setLocalURL(""))}}
+            onChange={(event) => setUseLocalURL(event.target.checked)}
           />
         </Box>
+
+        {useLocalURL && (
+          <Input
+            startDecorator={<HomeIcon />}
+            placeholder="Your Instance URL e.g 'lemmy.tgxn.net'"
+            value={localURL}
+            sx={{
+              width: { xs: "100%", sm: 300 },
+              flexShrink: 0,
+            }}
+            onChange={(event) =>
+              setLocalURL(
+                event.target.value
+                  .replace("http:", "")
+                  .replace("https:", "")
+                  .replace("//", "")
+                  .replace("/", ""),
+              )
+            }
+          />
+        )}
+
         <Box
           sx={{
             display: "flex",
@@ -211,7 +225,7 @@ export default function Communities() {
         {isSuccess && !processingData && (
           <Grid container spacing={2}>
             {communitiesData.map((community, index) => (
-              <CommunityCard key={index} community={community} localURL={localURL}/>
+              <CommunityCard key={index} community={community} localURL={localURL} />
             ))}
           </Grid>
         )}


### PR DESCRIPTION
Add a checkbox toggle and input box to the front end to allow the user to automatically change all the links on the "communities" tab to be within their instance.

-Edit-
Addresses:  #31, #40; the implementation here is a relatively simple way to address these issues