### PR TITLE
Add support for nodeinfo 2.1 (Lemmy 0.19.4)

### DIFF
--- a/crawler/src/crawl/instance.js
+++ b/crawler/src/crawl/instance.js
@@ -57,7 +57,7 @@ export default class InstanceCrawler {
     }
 
     for (var linkRel of wellKnownInfo.data.links) {
-      if (linkRel.rel == "http://nodeinfo.diaspora.software/ns/schema/2.0") {
+      if (linkRel.rel == "http://nodeinfo.diaspora.software/ns/schema/2.0" || linkRel.rel == "http://nodeinfo.diaspora.software/ns/schema/2.1") {
         nodeinfoUrl = linkRel.href;
       }
     }


### PR DESCRIPTION
Lemmy 0.19.4 switched to nodeinfo 2.1, it seems currently, no 0.19.4 instances are visible. Is this enough to fix it?