### PR TITLE
Small naming tweak for Piefed communities page

### DIFF
--- a/frontend/src/pages/PiefedCommunities.tsx
+++ b/frontend/src/pages/PiefedCommunities.tsx
@@ -272,7 +272,7 @@ function PiefedCommunities() {
                 // decimalScale={2}
                 // thousandSeparator={","}
               />{" "}
-              magazines
+              communities
             </Typography>
           )}
 


### PR DESCRIPTION
The piefed page currently says "showing XX magazines" - I missed that on the first pass. This updates it to say "showing XX communities"